### PR TITLE
Don't try to convert unicode types to str types.

### DIFF
--- a/texttable.py
+++ b/texttable.py
@@ -375,7 +375,10 @@ class Texttable:
         try:
             f = float(x)
         except:
-            return str(x)
+            if type(x) is unicode:
+                return x
+            else:
+                return str(x)
 
         n = self._precision
         dtype = self._dtype[i]
@@ -387,7 +390,10 @@ class Texttable:
         elif dtype == 'e':
             return '%.*e' % (n, f)
         elif dtype == 't':
-            return str(x)
+            if type(x) is unicode:
+                return x
+            else:
+                return str(x)
         else:
             if f - round(f) == 0:
                 if abs(f) > 1e8:
@@ -594,11 +600,12 @@ class Texttable:
                     if not lost_color:
                         lost_color = attr
             for c in cell.split('\n'):
-                try:
-                    c = unicode(c, 'utf')
-                except UnicodeDecodeError, strerror:
-                    sys.stderr.write("UnicodeDecodeError exception for string '%s': %s\n" % (c, strerror))
-                    c = unicode(c, 'utf', 'replace')
+                if type(c) is not unicode:
+                    try:
+                        c = unicode(c, 'utf')
+                    except UnicodeDecodeError, strerror:
+                        sys.stderr.write("UnicodeDecodeError exception for string '%s': %s\n" % (c, strerror))
+                        c = unicode(c, 'utf', 'replace')
                 try:
                     array.extend(
                         [get_color_string(


### PR DESCRIPTION
I ran into a problem similar to issue #1 and I think this should solve it.  Or at least get a little closer to a solution.  I can't claim to have done exhaustive testing, but my case (database record with a utf8 character) and the test case from #1 both work with these changes.  And the output of `python texttable.py` appears to still be the same after these changes.
